### PR TITLE
feat: 改善阅读缩进与概念交互

### DIFF
--- a/frontend/src/components/entity-cards/EntityCardDrawer.test.tsx
+++ b/frontend/src/components/entity-cards/EntityCardDrawer.test.tsx
@@ -1,0 +1,33 @@
+import { act, cleanup, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it } from "vitest"
+import { MemoryRouter } from "react-router-dom"
+import { useEntityCardStore } from "@/stores/entityCardStore"
+import { EntityCardDrawer } from "./EntityCardDrawer"
+
+describe("EntityCardDrawer concept popup", () => {
+  afterEach(() => {
+    cleanup()
+    useEntityCardStore.setState({ open: false, conceptPopup: null })
+  })
+
+  it("shows concept details without requiring an entity profile drawer", () => {
+    render(
+      <MemoryRouter>
+        <EntityCardDrawer novelId="novel-1" />
+      </MemoryRouter>,
+    )
+
+    act(() => {
+      useEntityCardStore.getState().openConceptPopup({
+        name: "罗汉金身",
+        definition: "少林修行所追求的高深境界。",
+        category: "修炼境界",
+        related: ["法身"],
+      })
+    })
+
+    expect(screen.getByRole("dialog").textContent).toContain("罗汉金身")
+    expect(screen.getByRole("dialog").textContent).toContain("修炼境界")
+    expect(screen.getByRole("dialog").textContent).toContain("法身")
+  })
+})

--- a/frontend/src/components/entity-cards/EntityCardDrawer.tsx
+++ b/frontend/src/components/entity-cards/EntityCardDrawer.tsx
@@ -105,18 +105,20 @@ export function EntityCardDrawer({ novelId }: EntityCardDrawerProps) {
     return () => window.removeEventListener("keydown", onKey)
   }, [open, close])
 
-  if (!open) return null
+  if (!open && !conceptPopup) return null
 
   return (
     <>
-      {/* Backdrop */}
-      <div
-        className="fixed inset-0 z-40 bg-black/20"
-        onClick={close}
-      />
+      {open && (
+        <>
+          {/* Backdrop */}
+          <div
+            className="fixed inset-0 z-40 bg-black/20"
+            onClick={close}
+          />
 
-      {/* Drawer */}
-      <div className="fixed top-0 right-0 z-50 flex h-screen w-full flex-col border-l bg-background shadow-lg sm:w-[420px]">
+          {/* Drawer */}
+          <div className="fixed top-0 right-0 z-50 flex h-screen w-full flex-col border-l bg-background shadow-lg sm:w-[420px]">
         {/* Header with breadcrumbs */}
         <div className="flex items-center gap-2 border-b px-4 py-3">
           <div className="flex-1 overflow-hidden">
@@ -229,7 +231,9 @@ export function EntityCardDrawer({ novelId }: EntityCardDrawerProps) {
             </>
           )}
         </div>
-      </div>
+          </div>
+        </>
+      )}
 
       {/* Concept Popup */}
       {conceptPopup && (
@@ -250,13 +254,19 @@ function ConceptPopup({
   onClose: () => void
 }) {
   return (
-    <div className="fixed inset-0 z-[60] flex items-center justify-center" onClick={onClose}>
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/20"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="concept-popup-title"
+      onClick={onClose}
+    >
       <div
         className="w-80 rounded-lg border bg-background p-4 shadow-xl"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="mb-2 flex items-center justify-between">
-          <h4 className="font-bold">{data.name}</h4>
+          <h4 id="concept-popup-title" className="font-bold">{data.name}</h4>
           <span className="text-muted-foreground rounded bg-muted px-1.5 py-0.5 text-[10px]">
             {data.category}
           </span>

--- a/frontend/src/pages/ReadingPage.tsx
+++ b/frontend/src/pages/ReadingPage.tsx
@@ -14,6 +14,7 @@ import {
   fetchBookmarks,
   addBookmark,
   deleteBookmark,
+  fetchConceptDetail,
 } from "@/api/client"
 import type { Bookmark, Chapter, ChapterEntity, EntityType, Novel, Scene } from "@/api/types"
 import { useReadingStore } from "@/stores/readingStore"
@@ -24,6 +25,7 @@ import {
   LINE_HEIGHT_MAP,
   type FontSize,
   type LineHeight,
+  type ParagraphIndent,
 } from "@/stores/readingSettingsStore"
 import { EntityCardDrawer } from "@/components/entity-cards/EntityCardDrawer"
 import { ScenePanel, SCENE_BORDER_COLORS } from "@/components/shared/ScenePanel"
@@ -389,8 +391,10 @@ export default function ReadingPage() {
   const reset = useReadingStore((s) => s.reset)
 
   const openEntityCard = useEntityCardStore((s) => s.openCard)
+  const openConceptPopup = useEntityCardStore((s) => s.openConceptPopup)
   const {
-    fontSize, lineHeight, setFontSize, setLineHeight,
+    fontSize, lineHeight, paragraphIndent,
+    setFontSize, setLineHeight, setParagraphIndent,
     highlightEnabled, setHighlightEnabled,
     hiddenEntityTypes, toggleEntityType,
   } = useReadingSettingsStore()
@@ -448,11 +452,30 @@ export default function ReadingPage() {
 
   const handleEntityClick = useCallback(
     (name: string, type: string) => {
-      if (type === "concept") return // concepts have no profile card
       const canonical = aliasMap[name] ?? name
+      if (type === "concept") {
+        if (!novelId) return
+        fetchConceptDetail(novelId, canonical)
+          .then((data) => {
+            const detail = data as {
+              name?: string
+              definition?: string
+              category?: string
+              related_concepts?: string[]
+            }
+            openConceptPopup({
+              name: detail.name ?? canonical,
+              definition: detail.definition ?? "",
+              category: detail.category ?? "概念",
+              related: detail.related_concepts ?? [],
+            })
+          })
+          .catch(() => {})
+        return
+      }
       openEntityCard(canonical, type as EntityType)
     },
-    [openEntityCard, aliasMap],
+    [aliasMap, novelId, openConceptPopup, openEntityCard],
   )
 
   // Filtered entities for highlight (2.6)
@@ -966,9 +989,11 @@ export default function ReadingPage() {
               <ReadingSettingsPanel
                 fontSize={fontSize}
                 lineHeight={lineHeight}
+                paragraphIndent={paragraphIndent}
                 hiddenEntityTypes={hiddenEntityTypes}
                 onFontSizeChange={setFontSize}
                 onLineHeightChange={setLineHeight}
+                onParagraphIndentChange={setParagraphIndent}
                 onToggleEntityType={toggleEntityType}
                 onClose={() => setShowSettings(false)}
               />
@@ -1083,8 +1108,9 @@ export default function ReadingPage() {
                           <p
                             key={i}
                             data-para={i}
+                            style={{ textIndent: paragraphIndent === "two" ? "2em" : undefined }}
                             className={cn(
-                              "mb-2 transition-colors",
+                              "mb-2 whitespace-pre-wrap transition-colors",
                               sceneIdx != null && `border-l-3 pl-3 ${borderColor}`,
                               isActive && "bg-accent/30 rounded-r",
                             )}
@@ -1096,9 +1122,17 @@ export default function ReadingPage() {
                     )}
                   </div>
                 ) : (
-                  /* Normal whole-block rendering */
-                  <div className={cn("whitespace-pre-wrap", FONT_SIZE_MAP[fontSize], LINE_HEIGHT_MAP[lineHeight])}>
-                    {renderText(currentChapter.content)}
+                  /* Paragraph-level rendering so indentation applies to every paragraph */
+                  <div className={cn(FONT_SIZE_MAP[fontSize], LINE_HEIGHT_MAP[lineHeight])}>
+                    {paragraphs.map((p, i) => (
+                      <p
+                        key={i}
+                        className="mb-2 whitespace-pre-wrap"
+                        style={{ textIndent: paragraphIndent === "two" ? "2em" : undefined }}
+                      >
+                        {renderText(p)}
+                      </p>
+                    ))}
                   </div>
                 )}
               </>
@@ -1153,17 +1187,21 @@ export default function ReadingPage() {
 function ReadingSettingsPanel({
   fontSize,
   lineHeight,
+  paragraphIndent,
   hiddenEntityTypes,
   onFontSizeChange,
   onLineHeightChange,
+  onParagraphIndentChange,
   onToggleEntityType,
   onClose,
 }: {
   fontSize: FontSize
   lineHeight: LineHeight
+  paragraphIndent: ParagraphIndent
   hiddenEntityTypes: string[]
   onFontSizeChange: (s: FontSize) => void
   onLineHeightChange: (h: LineHeight) => void
+  onParagraphIndentChange: (indent: ParagraphIndent) => void
   onToggleEntityType: (type: string) => void
   onClose: () => void
 }) {
@@ -1220,6 +1258,29 @@ function ReadingSettingsPanel({
                 onClick={() => onLineHeightChange(l.value)}
               >
                 {l.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="mb-3">
+          <span className="text-muted-foreground mb-1 block text-xs">首行缩进</span>
+          <div className="flex gap-1">
+            {([
+              { value: "none", label: "无" },
+              { value: "two", label: "两个字" },
+            ] as const).map((option) => (
+              <button
+                key={option.value}
+                className={cn(
+                  "flex-1 rounded px-2 py-1 text-xs transition-colors",
+                  paragraphIndent === option.value
+                    ? "bg-primary text-primary-foreground"
+                    : "bg-muted hover:bg-accent",
+                )}
+                onClick={() => onParagraphIndentChange(option.value)}
+              >
+                {option.label}
               </button>
             ))}
           </div>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -42,7 +42,14 @@ export default function SettingsPage() {
   const [envLoading, setEnvLoading] = useState(true)
   const [novels, setNovels] = useState<Novel[]>([])
 
-  const { fontSize, lineHeight, setFontSize, setLineHeight } = useReadingSettingsStore()
+  const {
+    fontSize,
+    lineHeight,
+    paragraphIndent,
+    setFontSize,
+    setLineHeight,
+    setParagraphIndent,
+  } = useReadingSettingsStore()
   const { theme, setTheme } = useThemeStore()
 
   // Import state
@@ -1431,6 +1438,26 @@ export default function SettingsPage() {
                 </div>
                 <p className="text-[10px] text-muted-foreground mt-1">
                   当前: {{ compact: "1.6x", normal: "2.0x", loose: "2.6x" }[lineHeight]}
+                </p>
+              </div>
+
+              {/* First-line indent */}
+              <div>
+                <span className="text-sm block mb-2">首行缩进</span>
+                <div className="flex gap-2">
+                  {([["none", "无"], ["two", "两个字"]] as const).map(([value, label]) => (
+                    <Button
+                      key={value}
+                      variant={paragraphIndent === value ? "default" : "outline"}
+                      size="xs"
+                      onClick={() => setParagraphIndent(value)}
+                    >
+                      {label}
+                    </Button>
+                  ))}
+                </div>
+                <p className="text-[10px] text-muted-foreground mt-1">
+                  默认使用两个汉字宽度
                 </p>
               </div>
 

--- a/frontend/src/stores/readingSettingsStore.test.ts
+++ b/frontend/src/stores/readingSettingsStore.test.ts
@@ -1,0 +1,18 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { useReadingSettingsStore } from "./readingSettingsStore"
+
+describe("readingSettingsStore", () => {
+  beforeEach(() => {
+    useReadingSettingsStore.setState({ paragraphIndent: "two" })
+  })
+
+  it("uses a two-character first-line indent by default", () => {
+    expect(useReadingSettingsStore.getState().paragraphIndent).toBe("two")
+  })
+
+  it("allows readers to disable first-line indentation", () => {
+    useReadingSettingsStore.getState().setParagraphIndent("none")
+
+    expect(useReadingSettingsStore.getState().paragraphIndent).toBe("none")
+  })
+})

--- a/frontend/src/stores/readingSettingsStore.ts
+++ b/frontend/src/stores/readingSettingsStore.ts
@@ -3,14 +3,17 @@ import { persist } from "zustand/middleware"
 
 export type FontSize = "small" | "medium" | "large" | "xlarge"
 export type LineHeight = "compact" | "normal" | "loose"
+export type ParagraphIndent = "none" | "two"
 
 interface ReadingSettingsState {
   fontSize: FontSize
   lineHeight: LineHeight
+  paragraphIndent: ParagraphIndent
   highlightEnabled: boolean
   hiddenEntityTypes: string[]
   setFontSize: (size: FontSize) => void
   setLineHeight: (height: LineHeight) => void
+  setParagraphIndent: (indent: ParagraphIndent) => void
   setHighlightEnabled: (enabled: boolean) => void
   toggleEntityType: (type: string) => void
 }
@@ -33,10 +36,12 @@ export const useReadingSettingsStore = create<ReadingSettingsState>()(
     (set) => ({
       fontSize: "medium",
       lineHeight: "normal",
+      paragraphIndent: "two",
       highlightEnabled: true,
       hiddenEntityTypes: [],
       setFontSize: (fontSize) => set({ fontSize }),
       setLineHeight: (lineHeight) => set({ lineHeight }),
+      setParagraphIndent: (paragraphIndent) => set({ paragraphIndent }),
       setHighlightEnabled: (highlightEnabled) => set({ highlightEnabled }),
       toggleEntityType: (type) =>
         set((s) => ({


### PR DESCRIPTION
## 变更

- 新增首行缩进阅读偏好，默认两个汉字宽度，可在阅读弹窗和全局设置中关闭
- 正文改为逐段渲染，使每一段都能正确缩进，场景模式保持一致
- 修复概念高亮显示为可点击但点击无响应的问题，复用现有概念详情弹窗
- 为设置状态和概念弹窗补充测试

## 验证

- npm run build
- npx vitest run：4 个测试文件、12 个测试全部通过
- 浏览器实测：默认缩进计算值为 2em；罗汉金身可打开详情

## 已知基线

全量 ESLint 当前仍受仓库既有的 60 个错误影响；本次涉及文件没有新增该类错误。